### PR TITLE
Splicing annotation

### DIFF
--- a/bamdash/scripts/data.py
+++ b/bamdash/scripts/data.py
@@ -4,6 +4,7 @@ contains defs for data analysis
 # BUILT INS
 import statistics
 import math
+import sys
 
 # LIBS
 import pandas as pd
@@ -78,6 +79,9 @@ def bam_to_coverage_df(bam_file, ref, min_cov, quality_thres):
     """
     # parse bam
     bam = pysam.AlignmentFile(bam_file, "rb")
+
+    if ref not in bam.references:
+        sys.exit(f'WARNING: ref id does not exist in bam file. Available references are {bam.references}')
 
     coverage, position = [], []
     # count coverage at each pos

--- a/bamdash/scripts/data.py
+++ b/bamdash/scripts/data.py
@@ -2,7 +2,6 @@
 contains defs for data analysis
 """
 # BUILT INS
-import statistics
 import math
 import sys
 

--- a/bamdash/scripts/data.py
+++ b/bamdash/scripts/data.py
@@ -185,7 +185,11 @@ def define_track_position(feature_dict):
         # -> move to new track
         for annotation in feature_dict[feature_type]:
             track = 0
-            positions = [int(x) for x in annotation.split(" ")]
+            try:
+                positions = [int(x) for x in annotation.split(" ")]
+            # edge case for positions that start with >
+            except ValueError:
+                positions = [int(x[1:]) for x in annotation.split(" ")]
             while positions[0] < track_stops[track]:
                 track += 1
                 # if all prior tracks are potentially causing an overlap
@@ -218,6 +222,7 @@ def genbank_to_dict(gb_file, coverage_df, ref, min_cov):
 
     for gb_record in SeqIO.parse(open(gb_file, "r"), "genbank"):
         if gb_record.id != ref and gb_record.name != ref:
+            print('WARNING: ref id does not match genbank')
             break
         seq = gb_record.seq
         for feature in gb_record.features:
@@ -231,9 +236,9 @@ def genbank_to_dict(gb_file, coverage_df, ref, min_cov):
             feature_dict[feature.type][f"{start} {stop}"]["mean coverage"] = mean_cov
             feature_dict[feature.type][f"{start} {stop}"][f"% recovery >= {min_cov}x"] = rec
             # define strand info
-            if feature.strand == 1:
+            if feature.location.strand == 1:
                 feature_dict[feature.type][f"{start} {stop}"]["strand"] = "+"
-            elif feature.strand == -1:
+            elif feature.location.strand == -1:
                 feature_dict[feature.type][f"{start} {stop}"]["strand"] = "-"
             else:
                 feature_dict[feature.type][f"{start} {stop}"]["strand"] = "NA"


### PR DESCRIPTION
NEW
- Previously BAMdash would ignore spliced genes and annotate also variants that were not actually in coding regions. This is now fixed in this PR. 
- Moreover, features that have multiple genomic locations are now properly displayed.
![Bildschirmfoto vom 2025-06-03 19-23-54](https://github.com/user-attachments/assets/251f7e33-80b2-4db8-b48d-6d01e06fdf4d)
- added warning if ref id is not found in bam and display available ids to improve user friendliness


FIXES:
- smaller fixes with biopython compatibility

