### PR TITLE
ensure compatibility with kaleido

### DIFF
--- a/bamdash/__init__.py
+++ b/bamdash/__init__.py
@@ -1,3 +1,3 @@
 """interactively visualize coverage and tracks"""
 _program = "bamdash"
-__version__ = "0.4.3"
+__version__ = "0.4.4"

--- a/bamdash/command.py
+++ b/bamdash/command.py
@@ -12,6 +12,7 @@ import json
 import plotly.io as pio
 import pandas as pd
 from plotly.subplots import make_subplots
+import kaleido
 
 # BAMDASH
 from bamdash.scripts import data
@@ -293,7 +294,6 @@ def main(sysargs=sys.argv[1:]):
         fig.update_layout(updatemenus=[dict(visible=False)])  # no buttons
         fig.update_layout(annotations=[dict(visible=False)])  # no annotations
         # write static image
-        pio.kaleido.scope.mathjax = None  # fix so no weird box is shown
         fig.write_image(f"{args.reference}_plot.{args.export_static}", width=args.dimensions[0], height=args.dimensions[1])
 
     # dump track data

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     license_files=('LICENSE'),
     packages=find_packages(),
     install_requires=[
-        "kaleido>=0.2.1",
+        "kaleido==0.2.*",
         "pandas>=1.4.4",
         "plotly>=5.17.0",
         "pysam>=0.21.0",


### PR DESCRIPTION
- downgraded kaleido engine to 0.2.* as 1.0 needs chrome installed
- removed pio.kaleido.scope.mathjax = None as mathjax is now bundeled with plotly